### PR TITLE
feat: parse doctype in `Scanner`

### DIFF
--- a/src/syntax.zig
+++ b/src/syntax.zig
@@ -104,3 +104,35 @@ pub inline fn isEncodingChar(c: u21) bool {
         else => false,
     };
 }
+
+pub inline fn isPubidChar(c: u21) bool {
+    return switch (c) {
+        ' ',
+        '\r',
+        '\n',
+        'a'...'z',
+        'A'...'Z',
+        '0'...'9',
+        '-',
+        '\'',
+        '(',
+        ')',
+        '+',
+        ',',
+        '.',
+        '/',
+        ':',
+        '=',
+        '?',
+        ';',
+        '!',
+        '*',
+        '#',
+        '@',
+        '$',
+        '_',
+        '%',
+        => true,
+        else => false,
+    };
+}


### PR DESCRIPTION
Closes #9

This is not done and perhaps never will be in its current form. It is just too complex, bloats the number of states in the parser, and is tedious to write. It is also not entirely clear how to correctly model the returned tokens.

A better solution (which will be taken at some point) might be to have a separate parser just for doctype stuff which can work alongside `Scanner` for people who really need it.