### PR TITLE
perf: rework decoder interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,23 +123,79 @@ parsing through an entire XML file without doing any additional processing. The
 XML file is loaded completely into memory first, then the parser is executed on
 it until it completes.
 
-Below are some benchmarking results as of commit
-`e9809855f7ee3403efa1fdc5f9010182f47361d0`, as performed on my laptop. The
-results were obtained by executing [poop](https://github.com/andrewrk/poop) on
-the benchmark implementations.
+Below are some benchmarking results as of August 14, 2023, using Zig
+`0.12.0-dev.906+2d7d037c4`, as performed on my laptop. The results were obtained
+by executing [poop](https://github.com/andrewrk/poop) on the benchmark
+implementations.
 
 ### GTK 4 GIR
 
-This is a 7.6MiB XML file containing GObject introspection metadata for GTK 4.
+This is a 5.7MB XML file containing GObject introspection metadata for GTK 4. In
+the output below, libxml2 is used as the baseline. The three benchmarks
+`reader`, `token_reader`, and `scanner` test the three APIs provided by this
+library, and the mxml and yxml libraries are also included for comparison.
 
-| Implementation             | Execution time  | Memory usage    |
-| -------------------------- | --------------- | --------------- |
-| zig-xml (`Reader`)         | 242ms ± 5.50ms  | 9.12MB ± 66.5KB |
-| zig-xml (`TokenReader`)    | 169ms ± 13.4ms  | 9.07MB ± 97.9KB |
-| zig-xml (`Scanner`)        | 40.2ms ± 2.25ms | 9.09MB ± 97.0KB |
-| libxml2 (`xmlreader.h`)    | 74.0ms ± 3.16ms | 10.4MB ± 104KB  |
-| mxml (`mxmlSAXLoadString`) | 97.1ms ± 1.63ms | 9.12MB ± 64.9KB |
-| yxml                       | 36.2ms ± 999us  | 9.09MB ± 92.3KB |
+```
+Benchmark 1 (78 runs): zig-out/bin/libxml2 Gtk-4.0.gir
+  measurement          mean ± σ            min … max           outliers         delta
+  wall_time          64.2ms ± 1.87ms    55.5ms … 70.1ms          4 ( 5%)        0%
+  peak_rss           14.6MB ± 76.4KB    14.4MB … 14.7MB          0 ( 0%)        0%
+  cpu_cycles          196M  ± 1.03M      194M  …  200M           3 ( 4%)        0%
+  instructions        409M  ± 43.1       409M  …  409M           0 ( 0%)        0%
+  cache_references   5.44M  ±  325K     5.08M  … 6.97M           5 ( 6%)        0%
+  cache_misses       66.0K  ± 5.36K     55.0K  … 91.0K           3 ( 4%)        0%
+  branch_misses       874K  ± 3.80K      868K  …  890K           1 ( 1%)        0%
+
+Benchmark 2 (30 runs): zig-out/bin/reader Gtk-4.0.gir
+  measurement          mean ± σ            min … max           outliers         delta
+  wall_time           170ms ± 1.59ms     167ms …  173ms          0 ( 0%)        💩+164.2% ±  1.2%
+  peak_rss           7.29MB ± 73.8KB    7.08MB … 7.34MB          0 ( 0%)        ⚡- 50.0% ±  0.2%
+  cpu_cycles          583M  ± 2.88M      579M  …  590M           0 ( 0%)        💩+196.9% ±  0.4%
+  instructions       1.38G  ± 32.2      1.38G  … 1.38G           0 ( 0%)        💩+237.2% ±  0.0%
+  cache_references    751K  ±  135K      580K  … 1.12M           0 ( 0%)        ⚡- 86.2% ±  2.2%
+  cache_misses       17.5K  ± 5.41K     12.9K  … 34.5K           3 (10%)        ⚡- 73.5% ±  3.5%
+  branch_misses      1.06M  ± 10.9K     1.05M  … 1.11M           2 ( 7%)        💩+ 21.5% ±  0.3%
+
+Benchmark 3 (38 runs): zig-out/bin/token_reader Gtk-4.0.gir
+  measurement          mean ± σ            min … max           outliers         delta
+  wall_time           135ms ± 1.59ms     132ms …  138ms          0 ( 0%)        💩+110.4% ±  1.1%
+  peak_rss           7.31MB ± 54.2KB    7.21MB … 7.34MB          8 (21%)        ⚡- 49.8% ±  0.2%
+  cpu_cycles          462M  ± 2.20M      459M  …  467M           0 ( 0%)        💩+135.5% ±  0.3%
+  instructions       1.14G  ± 21.0      1.14G  … 1.14G           0 ( 0%)        💩+179.9% ±  0.0%
+  cache_references    237K  ± 7.40K      225K  …  255K           0 ( 0%)        ⚡- 95.6% ±  1.9%
+  cache_misses       10.1K  ± 1.29K     8.16K  … 13.2K           0 ( 0%)        ⚡- 84.8% ±  2.7%
+  branch_misses       815K  ±  919       813K  …  816K           3 ( 8%)        ⚡-  6.8% ±  0.1%
+
+Benchmark 4 (103 runs): zig-out/bin/scanner Gtk-4.0.gir
+  measurement          mean ± σ            min … max           outliers         delta
+  wall_time          48.6ms ± 1.82ms    45.8ms … 55.2ms          4 ( 4%)        ⚡- 24.3% ±  0.8%
+  peak_rss           7.27MB ± 87.8KB    7.08MB … 7.34MB          0 ( 0%)        ⚡- 50.1% ±  0.2%
+  cpu_cycles          152M  ± 3.48M      151M  …  177M           5 ( 5%)        ⚡- 22.4% ±  0.4%
+  instructions        472M  ± 19.9       472M  …  472M           0 ( 0%)        💩+ 15.6% ±  0.0%
+  cache_references    209K  ± 1.80K      207K  …  222K           4 ( 4%)        ⚡- 96.2% ±  1.2%
+  cache_misses       7.95K  ±  179      7.59K  … 8.50K           0 ( 0%)        ⚡- 88.0% ±  1.6%
+  branch_misses       511K  ±  874       510K  …  518K          13 (13%)        ⚡- 41.6% ±  0.1%
+
+Benchmark 5 (63 runs): zig-out/bin/mxml Gtk-4.0.gir
+  measurement          mean ± σ            min … max           outliers         delta
+  wall_time          80.2ms ± 2.44ms    76.0ms … 87.9ms          3 ( 5%)        💩+ 24.9% ±  1.1%
+  peak_rss           7.44MB ± 56.3KB    7.34MB … 7.47MB         15 (24%)        ⚡- 48.9% ±  0.2%
+  cpu_cycles          262M  ± 2.95M      258M  …  281M           1 ( 2%)        💩+ 33.4% ±  0.4%
+  instructions        762M  ± 56.7K      762M  …  762M           3 ( 5%)        💩+ 86.4% ±  0.0%
+  cache_references    401K  ±  473K      272K  … 3.08M          10 (16%)        ⚡- 92.6% ±  2.4%
+  cache_misses       14.2K  ± 2.62K     12.0K  … 31.1K           2 ( 3%)        ⚡- 78.5% ±  2.2%
+  branch_misses      1.02M  ± 99.5K      998K  … 1.79M           4 ( 6%)        💩+ 16.3% ±  2.5%
+
+Benchmark 6 (196 runs): zig-out/bin/yxml Gtk-4.0.gir
+  measurement          mean ± σ            min … max           outliers         delta
+  wall_time          25.4ms ± 1.03ms    23.9ms … 34.3ms          3 ( 2%)        ⚡- 60.4% ±  0.5%
+  peak_rss           7.29MB ± 77.0KB    7.08MB … 7.34MB          0 ( 0%)        ⚡- 50.0% ±  0.1%
+  cpu_cycles         71.0M  ± 1.03M     70.5M  … 84.2M           5 ( 3%)        ⚡- 63.8% ±  0.1%
+  instructions        236M  ± 20.1       236M  …  236M           0 ( 0%)        ⚡- 42.2% ±  0.0%
+  cache_references    202K  ±  805       201K  …  210K           7 ( 4%)        ⚡- 96.3% ±  0.8%
+  cache_misses       8.00K  ±  215      7.64K  … 9.57K           4 ( 2%)        ⚡- 87.9% ±  1.1%
+  branch_misses       239K  ±  787       238K  …  248K          21 (11%)        ⚡- 72.7% ±  0.1%
+```
 
 ## License
 

--- a/bench/build.zig
+++ b/bench/build.zig
@@ -18,6 +18,7 @@ pub fn build(b: *Build) !void {
     bench_reader.linkLibC();
 
     const libxml2 = b.dependency("libxml2", .{
+        .optimize = .ReleaseFast,
         .iconv = false,
         .lzma = false,
         .zlib = false,

--- a/bench/src/scanner.zig
+++ b/bench/src/scanner.zig
@@ -1,13 +1,16 @@
+const std = @import("std");
 const xml = @import("xml");
 
 pub const main = @import("common.zig").main;
 
 pub fn runBench(data: []const u8) !void {
     var scanner = xml.Scanner{};
+    var data_stream = std.io.fixedBufferStream(data);
     var decoder = xml.encoding.Utf8Decoder{};
-    for (data) |b| {
-        if (try decoder.next(b)) |c| {
-            _ = try scanner.next(c, 1);
-        }
+    var buf: [4]u8 = undefined;
+    while (true) {
+        const c = try decoder.readCodepoint(data_stream.reader(), &buf);
+        if (!c.present) break;
+        _ = try scanner.next(c.codepoint, c.byte_length);
     }
 }

--- a/src/encoding.zig
+++ b/src/encoding.zig
@@ -6,18 +6,16 @@
 //!
 //! - `const max_encoded_codepoint_len` - the maximum number of bytes a
 //!    single Unicode codepoint may occupy in encoded form.
-//! - `fn next(self: *Decoder, b: u8) Error!?u21` - accepts a single byte of
-//!   input, returning an error if the byte is invalid in the current state of
-//!   the decoder, a valid Unicode codepoint, or `null` if the byte is valid
-//!   but there is not yet a full codepoint to return.
+//! - `fn readCodepoint(self: *Decoder, reader: anytype, buf: []u8) (Error || @TypeOf(reader).Error))!ReadResult` -
+//!   reads a single codepoint from a `std.io.GenericReader` and writes its UTF-8
+//!   encoding to `buf`. Should return `error.UnexpectedEndOfInput` if a full
+//!   codepoint cannot be read, `error.Overflow` if the UTF-8-encoded form cannot
+//!   be written to `buf`; other decoder-specific errors can also be used.
 //! - `fn adaptTo(self: *Decoder, encoding: []const u8) error{InvalidEncoding}!void` -
 //!   accepts a UTF-8-encoded encoding name and returns an error if the desired
 //!   encoding cannot be handled by the decoder. This is intended to support
 //!   `Decoder` implementations which adapt to the encoding declared by an XML
 //!   document.
-//! - `fn isUtf8Compatible(self: Decoder) bool` - returns whether this decoder
-//!   decodes a subset of UTF-8. It is always safe to return false if this is
-//!   not known.
 
 const std = @import("std");
 const ascii = std.ascii;
@@ -27,6 +25,26 @@ const Allocator = std.mem.Allocator;
 const ArrayListUnmanaged = std.ArrayListUnmanaged;
 const BoundedArray = std.BoundedArray;
 
+/// The result of reading a single codepoint successfully.
+pub const ReadResult = packed struct(u32) {
+    /// The codepoint read.
+    codepoint: u21,
+    /// The length of the codepoint encoded in UTF-8.
+    byte_length: u10,
+    /// If https://github.com/ziglang/zig/issues/104 is implemented, a much
+    /// better API would be to make `ReadResult` a `packed struct(u31)` instead
+    /// and use `?ReadResult` elsewhere. But, for now, this indicates whether
+    /// `codepoint` and `byte_length` are present, so that the whole thing fits
+    /// in a `u32` rather than unnecessarily taking up 8 bytes.
+    present: bool = true,
+
+    pub const none: ReadResult = .{
+        .codepoint = 0,
+        .byte_length = 0,
+        .present = false,
+    };
+};
+
 /// A decoder which handles UTF-8 or UTF-16, using a BOM to detect UTF-16
 /// endianness.
 ///
@@ -35,123 +53,134 @@ const BoundedArray = std.BoundedArray;
 pub const DefaultDecoder = struct {
     state: union(enum) {
         start,
-        utf16_be_bom,
-        utf16_le_bom,
         utf8: Utf8Decoder,
-        utf16_le: Utf16Decoder(.little),
-        utf16_be: Utf16Decoder(.big),
+        utf16_le: Utf16Decoder(.Little),
+        utf16_be: Utf16Decoder(.Big),
     } = .start,
 
-    pub const Error = error{ InvalidUtf8, InvalidUtf16 };
+    pub const Error = Utf8Decoder.Error || Utf16Decoder(.Little).Error || Utf16Decoder(.Big).Error;
 
     pub const max_encoded_codepoint_len = 4;
+    const bom = 0xFEFF;
+    const bom_byte_length = unicode.utf8CodepointSequenceLength(bom) catch unreachable;
 
-    pub fn next(self: *DefaultDecoder, b: u8) Error!?u21 {
+    pub fn readCodepoint(self: *DefaultDecoder, reader: anytype, buf: []u8) (Error || @TypeOf(reader).Error)!ReadResult {
         switch (self.state) {
-            .start => if (b == 0xFE) {
-                self.state = .utf16_be_bom;
-                return null;
-            } else if (b == 0xFF) {
-                self.state = .utf16_le_bom;
-                return null;
-            } else {
-                self.state = .{ .utf8 = .{} };
-                return try self.state.utf8.next(b);
-            },
-            .utf16_be_bom => if (b == 0xFF) {
+            .start => {},
+            inline else => |*inner| return inner.readCodepoint(reader, buf),
+        }
+        // If attempting to match the UTF-16 BOM fails for whatever reason, we
+        // will assume we are reading UTF-8.
+        self.state = .{ .utf8 = .{} };
+        const b = reader.readByte() catch |e| switch (e) {
+            error.EndOfStream => return error.UnexpectedEndOfInput,
+            else => |other| return other,
+        };
+        switch (b) {
+            0xFE => {
+                const b2 = reader.readByte() catch |e| switch (e) {
+                    error.EndOfStream => return error.InvalidUtf8,
+                    else => |other| return other,
+                };
+                if (b2 != 0xFF) return error.InvalidUtf8;
                 self.state = .{ .utf16_be = .{} };
-                return 0xFEFF;
-            } else {
-                self.state = .{ .utf8 = .{} };
-                return error.InvalidUtf8;
+                if (bom_byte_length > buf.len) return error.Overflow;
+                _ = unicode.utf8Encode(bom, buf) catch unreachable;
+                return .{ .codepoint = bom, .byte_length = bom_byte_length };
             },
-            .utf16_le_bom => if (b == 0xFE) {
+            0xFF => {
+                const b2 = reader.readByte() catch |e| switch (e) {
+                    error.EndOfStream => return error.InvalidUtf8,
+                    else => |other| return other,
+                };
+                if (b2 != 0xFE) return error.InvalidUtf8;
                 self.state = .{ .utf16_le = .{} };
-                return 0xFEFF;
-            } else {
-                self.state = .{ .utf8 = .{} };
-                return error.InvalidUtf8;
+                if (bom_byte_length > buf.len) return error.Overflow;
+                _ = unicode.utf8Encode(bom, buf) catch unreachable;
+                return .{ .codepoint = bom, .byte_length = bom_byte_length };
             },
-            inline else => |*decoder| return try decoder.next(b),
+            else => {
+                // The rest of this branch is copied from Utf8Decoder
+                const byte_length = unicode.utf8ByteSequenceLength(b) catch return error.InvalidUtf8;
+                if (byte_length > buf.len) return error.Overflow;
+                buf[0] = b;
+                if (byte_length == 1) return .{ .codepoint = b, .byte_length = 1 };
+                reader.readNoEof(buf[1..byte_length]) catch |e| switch (e) {
+                    error.EndOfStream => return error.UnexpectedEndOfInput,
+                    else => |other| return other,
+                };
+                const codepoint = switch (byte_length) {
+                    2 => unicode.utf8Decode2(buf[0..2]),
+                    3 => unicode.utf8Decode3(buf[0..3]),
+                    4 => unicode.utf8Decode4(buf[0..4]),
+                    else => unreachable,
+                } catch return error.InvalidUtf8;
+                return .{ .codepoint = codepoint, .byte_length = byte_length };
+            },
         }
     }
 
     pub fn adaptTo(self: *DefaultDecoder, encoding: []const u8) error{InvalidEncoding}!void {
         switch (self.state) {
-            .start, .utf16_be_bom, .utf16_le_bom => {},
+            .start => {},
             inline else => |*decoder| try decoder.adaptTo(encoding),
         }
-    }
-
-    pub inline fn isUtf8Compatible(self: DefaultDecoder) bool {
-        return self.state == .utf8;
     }
 };
 
 test DefaultDecoder {
     // UTF-8 no BOM
     {
-        var decoder = DefaultDecoder{};
-        try testing.expectEqual(@as(?u21, 'H'), try decoder.next('H'));
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0xC3));
-        try testing.expectEqual(@as(?u21, 'ü'), try decoder.next(0xBC));
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0xE6));
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0x97));
-        try testing.expectEqual(@as(?u21, '日'), try decoder.next(0xA5));
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0xF0));
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0x9F));
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0x98));
-        try testing.expectEqual(@as(?u21, '😀'), try decoder.next(0x80));
+        const input = "Hü日😀";
+        var decoder = try testDecode(DefaultDecoder, input, &.{
+            'H',
+            'ü',
+            '日',
+            '😀',
+        });
         try decoder.adaptTo("utf-8");
         try decoder.adaptTo("UTF-8");
     }
 
     // UTF-8 BOM
     {
-        var decoder = DefaultDecoder{};
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0xEF));
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0xBB));
-        try testing.expectEqual(@as(?u21, 0xFEFF), try decoder.next(0xBF));
-        try testing.expectEqual(@as(?u21, 'H'), try decoder.next('H'));
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0xC3));
-        try testing.expectEqual(@as(?u21, 'ü'), try decoder.next(0xBC));
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0xE6));
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0x97));
-        try testing.expectEqual(@as(?u21, '日'), try decoder.next(0xA5));
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0xF0));
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0x9F));
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0x98));
-        try testing.expectEqual(@as(?u21, '😀'), try decoder.next(0x80));
+        const input = "\u{FEFF}Hü日😀";
+        var decoder = try testDecode(DefaultDecoder, input, &.{
+            0xFEFF,
+            'H',
+            'ü',
+            '日',
+            '😀',
+        });
         try decoder.adaptTo("utf-8");
         try decoder.adaptTo("UTF-8");
     }
 
     // Invalid UTF-8 BOM
     {
-        var decoder = DefaultDecoder{};
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0xEF));
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0x00));
-        try testing.expectError(error.InvalidUtf8, decoder.next(0x00));
-        try testing.expectEqual(@as(?u21, 'H'), try decoder.next('H'));
+        const input = "\xEF\x00\x00H";
+        var decoder = try testDecode(DefaultDecoder, input, &.{
+            error.InvalidUtf8,
+            'H',
+        });
         try decoder.adaptTo("utf-8");
         try decoder.adaptTo("UTF-8");
     }
 
     // UTF-16BE BOM
     {
-        var decoder = DefaultDecoder{};
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0xFE));
-        try testing.expectEqual(@as(?u21, 0xFEFF), try decoder.next(0xFF));
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0x00));
-        try testing.expectEqual(@as(?u21, 'H'), try decoder.next('H'));
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0x00));
-        try testing.expectEqual(@as(?u21, 'ü'), try decoder.next(0xFC));
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0x65));
-        try testing.expectEqual(@as(?u21, '日'), try decoder.next(0xE5));
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0xD8));
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0x3D));
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0xDE));
-        try testing.expectEqual(@as(?u21, '😀'), try decoder.next(0x00));
+        const input = "\xFE\xFF" ++ // U+FEFF
+            "\x00H" ++
+            "\x00\xFC" ++ // ü
+            "\x65\xE5" ++ // 日
+            "\xD8\x3D\xDE\x00"; // 😀
+        var decoder = try testDecode(DefaultDecoder, input, &.{
+            0xFEFF,
+            'H',
+            'ü',
+            '日',
+            '😀',
+        });
         try decoder.adaptTo("utf-16");
         try decoder.adaptTo("UTF-16");
         try decoder.adaptTo("utf-16be");
@@ -160,29 +189,29 @@ test DefaultDecoder {
 
     // Invalid UTF-16BE BOM
     {
-        var decoder = DefaultDecoder{};
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0xFE));
-        try testing.expectError(error.InvalidUtf8, decoder.next(0x00));
-        try testing.expectEqual(@as(?u21, 'H'), try decoder.next('H'));
+        const input = "\xFE\x00H";
+        var decoder = try testDecode(DefaultDecoder, input, &.{
+            error.InvalidUtf8,
+            'H',
+        });
         try decoder.adaptTo("utf-8");
         try decoder.adaptTo("UTF-8");
     }
 
     // UTF-16LE BOM
     {
-        var decoder = DefaultDecoder{};
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0xFF));
-        try testing.expectEqual(@as(?u21, 0xFEFF), try decoder.next(0xFE));
-        try testing.expectEqual(@as(?u21, null), try decoder.next('H'));
-        try testing.expectEqual(@as(?u21, 'H'), try decoder.next(0x00));
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0xFC));
-        try testing.expectEqual(@as(?u21, 'ü'), try decoder.next(0x00));
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0xE5));
-        try testing.expectEqual(@as(?u21, '日'), try decoder.next(0x65));
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0x3D));
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0xD8));
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0x00));
-        try testing.expectEqual(@as(?u21, '😀'), try decoder.next(0xDE));
+        const input = "\xFF\xFE" ++ // U+FEFF
+            "H\x00" ++
+            "\xFC\x00" ++ // ü
+            "\xE5\x65" ++ // 日
+            "\x3D\xD8\x00\xDE"; // 😀
+        var decoder = try testDecode(DefaultDecoder, input, &.{
+            0xFEFF,
+            'H',
+            'ü',
+            '日',
+            '😀',
+        });
         try decoder.adaptTo("utf-16");
         try decoder.adaptTo("UTF-16");
         try decoder.adaptTo("utf-16le");
@@ -191,10 +220,11 @@ test DefaultDecoder {
 
     // Invalid UTF-16LE BOM
     {
-        var decoder = DefaultDecoder{};
-        try testing.expectEqual(@as(?u21, null), try decoder.next(0xFF));
-        try testing.expectError(error.InvalidUtf8, decoder.next(0xFF));
-        try testing.expectEqual(@as(?u21, 'H'), try decoder.next('H'));
+        const input = "\xFF\xFFH";
+        var decoder = try testDecode(DefaultDecoder, input, &.{
+            error.InvalidUtf8,
+            'H',
+        });
         try decoder.adaptTo("utf-8");
         try decoder.adaptTo("UTF-8");
     }
@@ -202,43 +232,36 @@ test DefaultDecoder {
 
 /// A decoder which handles only UTF-8.
 pub const Utf8Decoder = struct {
-    buffer: BoundedArray(u8, 4) = .{},
-    expecting: u3 = 0,
-
-    pub const Error = error{InvalidUtf8};
-
     pub const max_encoded_codepoint_len = 4;
 
-    pub fn next(self: *Utf8Decoder, b: u8) Error!?u21 {
-        if (self.expecting == 0) {
-            const len = unicode.utf8ByteSequenceLength(b) catch return error.InvalidUtf8;
-            if (len == 1) {
-                return b;
-            }
-            self.expecting = len;
-            self.buffer.appendAssumeCapacity(b);
-            return null;
-        } else {
-            self.buffer.appendAssumeCapacity(b);
-            if (self.buffer.len == self.expecting) {
-                const codepoint_or_error = unicode.utf8Decode(self.buffer.slice());
-                self.expecting = 0;
-                self.buffer.len = 0;
-                return codepoint_or_error catch error.InvalidUtf8;
-            } else {
-                return null;
-            }
-        }
+    pub const Error = error{ InvalidUtf8, Overflow, UnexpectedEndOfInput };
+
+    pub fn readCodepoint(_: *Utf8Decoder, reader: anytype, buf: []u8) (Error || @TypeOf(reader).Error)!ReadResult {
+        const b = reader.readByte() catch |e| switch (e) {
+            error.EndOfStream => return ReadResult.none,
+            else => |other| return other,
+        };
+        const byte_length = unicode.utf8ByteSequenceLength(b) catch return error.InvalidUtf8;
+        if (byte_length > buf.len) return error.Overflow;
+        buf[0] = b;
+        if (byte_length == 1) return .{ .codepoint = b, .byte_length = 1 };
+        reader.readNoEof(buf[1..byte_length]) catch |e| switch (e) {
+            error.EndOfStream => return error.UnexpectedEndOfInput,
+            else => |other| return other,
+        };
+        const codepoint = switch (byte_length) {
+            2 => unicode.utf8Decode2(buf[0..2]),
+            3 => unicode.utf8Decode3(buf[0..3]),
+            4 => unicode.utf8Decode4(buf[0..4]),
+            else => unreachable,
+        } catch return error.InvalidUtf8;
+        return .{ .codepoint = codepoint, .byte_length = byte_length };
     }
 
     pub fn adaptTo(_: *Utf8Decoder, encoding: []const u8) error{InvalidEncoding}!void {
         if (!ascii.eqlIgnoreCase(encoding, "utf-8")) {
             return error.InvalidEncoding;
         }
-    }
-
-    pub inline fn isUtf8Compatible(_: Utf8Decoder) bool {
-        return true;
     }
 };
 
@@ -258,7 +281,7 @@ test Utf8Decoder {
         "\xF7\xBF\xBF\xBF" ++
         // Surrogate halves
         "\xED\xA0\x80\xED\xBF\xBF";
-    const expected: []const (error{InvalidUtf8}!u21) = &.{
+    _ = try testDecode(Utf8Decoder, input, &.{
         '\x00',
         '\x01',
         ' ',
@@ -309,93 +332,52 @@ test Utf8Decoder {
         error.InvalidUtf8, // attempted U+1FFFFF
         error.InvalidUtf8, // U+D800
         error.InvalidUtf8, // U+DFFF
-    };
-
-    var decoded = ArrayListUnmanaged(error{InvalidUtf8}!u21){};
-    defer decoded.deinit(testing.allocator);
-    var decoder = Utf8Decoder{};
-    for (input) |b| {
-        if (decoder.next(b)) |maybe_c| {
-            if (maybe_c) |c| {
-                try decoded.append(testing.allocator, c);
-            }
-        } else |err| {
-            try decoded.append(testing.allocator, err);
-        }
-    }
-
-    try testing.expectEqualDeep(expected, decoded.items);
+    });
 }
 
-pub const Utf16Endianness = enum {
-    big,
-    little,
-};
-
 /// A decoder which handles only UTF-16 of a given endianness.
-pub fn Utf16Decoder(comptime endianness: Utf16Endianness) type {
+pub fn Utf16Decoder(comptime endian: std.builtin.Endian) type {
     return struct {
-        buffer: BoundedArray(u8, 2) = .{},
-        high_unit: ?u10 = null,
-
         const Self = @This();
 
-        pub const Error = error{InvalidUtf16};
+        pub const Error = error{ InvalidUtf16, Overflow, UnexpectedEndOfInput };
 
         pub const max_encoded_codepoint_len = 4;
 
-        pub fn next(self: *Self, b: u8) Error!?u21 {
-            self.buffer.appendAssumeCapacity(b);
-            if (self.buffer.len == 1) {
-                return null;
+        pub fn readCodepoint(_: *Self, reader: anytype, buf: []u8) (Error || @TypeOf(reader).Error)!ReadResult {
+            var u_buf: [2]u8 = undefined;
+            const u_len = try reader.readAll(&u_buf);
+            switch (u_len) {
+                0 => return ReadResult.none,
+                1 => return error.UnexpectedEndOfInput,
+                else => {},
             }
-            const u = self.takeCodeUnit();
-            if (self.high_unit) |high_unit| {
-                self.high_unit = null;
-                if (!isLowSurrogate(u)) {
-                    return error.InvalidUtf16;
-                }
-                return 0x10000 + ((@as(u21, high_unit) << 10) | surrogateValue(u));
-            } else if (isHighSurrogate(u)) {
-                self.high_unit = surrogateValue(u);
-                return null;
-            } else if (isLowSurrogate(u)) {
-                return error.InvalidUtf16;
-            } else {
-                return u;
-            }
-        }
-
-        inline fn takeCodeUnit(self: *Self) u16 {
-            const b1 = self.buffer.buffer[0];
-            const b2 = self.buffer.buffer[1];
-            self.buffer.len = 0;
-            return if (endianness == .big) (@as(u16, b1) << 8) + b2 else (@as(u16, b2) << 8) + b1;
-        }
-
-        inline fn isHighSurrogate(u: u16) bool {
-            return u & ~@as(u16, 0x3FF) == 0xD800;
-        }
-
-        inline fn isLowSurrogate(u: u16) bool {
-            return u & ~@as(u16, 0x3FF) == 0xDC00;
-        }
-
-        inline fn surrogateValue(u: u16) u10 {
-            return @intCast(u & 0x3FF);
+            const u = std.mem.readInt(u16, &u_buf, endian);
+            const code_unit_length = unicode.utf16CodeUnitSequenceLength(u) catch return error.InvalidUtf16;
+            const codepoint = switch (code_unit_length) {
+                1 => u,
+                2 => codepoint: {
+                    const low = reader.readInt(u16, endian) catch |e| switch (e) {
+                        error.EndOfStream => return error.UnexpectedEndOfInput,
+                        else => |other| return other,
+                    };
+                    break :codepoint unicode.utf16DecodeSurrogatePair(&.{ u, low }) catch return error.InvalidUtf16;
+                },
+                else => unreachable,
+            };
+            const byte_length = unicode.utf8CodepointSequenceLength(codepoint) catch unreachable;
+            if (byte_length > buf.len) return error.Overflow;
+            _ = unicode.utf8Encode(codepoint, buf) catch unreachable;
+            return .{ .codepoint = codepoint, .byte_length = byte_length };
         }
 
         pub fn adaptTo(_: *Self, encoding: []const u8) error{InvalidEncoding}!void {
             if (!(ascii.eqlIgnoreCase(encoding, "utf-16") or
-                (endianness == .big and ascii.eqlIgnoreCase(encoding, "utf-16be")) or
-                (endianness == .little and ascii.eqlIgnoreCase(encoding, "utf-16le"))))
+                (endian == .Big and ascii.eqlIgnoreCase(encoding, "utf-16be")) or
+                (endian == .Little and ascii.eqlIgnoreCase(encoding, "utf-16le"))))
             {
                 return error.InvalidEncoding;
             }
-        }
-
-        pub inline fn isUtf8Compatible(_: Self) bool {
-            return false;
         }
     };
 }
@@ -412,7 +394,7 @@ test Utf16Decoder {
             "\x00\xD8\x00\x00" ++ // unpaired high surrogate followed by U+0000
             "\xFF\xDF" // unpaired low surrogate
         ;
-        const expected: []const (error{InvalidUtf16}!u21) = &.{
+        _ = try testDecode(Utf16Decoder(.Little), input, &.{
             '\x00',
             'A',
             'b',
@@ -421,22 +403,7 @@ test Utf16Decoder {
             '😳',
             error.InvalidUtf16,
             error.InvalidUtf16,
-        };
-
-        var decoded = ArrayListUnmanaged(error{InvalidUtf16}!u21){};
-        defer decoded.deinit(testing.allocator);
-        var decoder = Utf16Decoder(.little){};
-        for (input) |b| {
-            if (decoder.next(b)) |maybe_c| {
-                if (maybe_c) |c| {
-                    try decoded.append(testing.allocator, c);
-                }
-            } else |err| {
-                try decoded.append(testing.allocator, err);
-            }
-        }
-
-        try testing.expectEqualDeep(expected, decoded.items);
+        });
     }
 
     // big-endian
@@ -450,7 +417,7 @@ test Utf16Decoder {
             "\xD8\x00\x00\x00" ++ // unpaired high surrogate followed by U+0000
             "\xDF\xFF" // unpaired low surrogate
         ;
-        const expected: []const (error{InvalidUtf16}!u21) = &.{
+        _ = try testDecode(Utf16Decoder(.Big), input, &.{
             '\x00',
             'A',
             'b',
@@ -459,21 +426,26 @@ test Utf16Decoder {
             '😳',
             error.InvalidUtf16,
             error.InvalidUtf16,
-        };
-
-        var decoded = ArrayListUnmanaged(error{InvalidUtf16}!u21){};
-        defer decoded.deinit(testing.allocator);
-        var decoder = Utf16Decoder(.big){};
-        for (input) |b| {
-            if (decoder.next(b)) |maybe_c| {
-                if (maybe_c) |c| {
-                    try decoded.append(testing.allocator, c);
-                }
-            } else |err| {
-                try decoded.append(testing.allocator, err);
-            }
-        }
-
-        try testing.expectEqualDeep(expected, decoded.items);
+        });
     }
+}
+
+fn testDecode(comptime Decoder: type, input: []const u8, expected: []const (Decoder.Error!u21)) !Decoder {
+    var decoder: Decoder = .{};
+    var decoded = ArrayListUnmanaged(Decoder.Error!u21){};
+    defer decoded.deinit(testing.allocator);
+    var input_stream = std.io.fixedBufferStream(input);
+    var buf: [4]u8 = undefined;
+    while (true) {
+        if (decoder.readCodepoint(input_stream.reader(), &buf)) |c| {
+            if (!c.present) break;
+            try decoded.append(testing.allocator, c.codepoint);
+        } else |err| {
+            try decoded.append(testing.allocator, err);
+        }
+    }
+
+    try testing.expectEqualDeep(expected, decoded.items);
+
+    return decoder;
 }


### PR DESCRIPTION
The updated interface decodes codepoints directly from a reader rather than being implemented as a state machine. This turns out to be considerably more efficient than the previous implementation, with around 25% improvement on the `token_reader` and `reader` benchmarks:

```
Benchmark 1 (27 runs): zig-out/bin-old/token_reader Gtk-4.0.gir
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           188ms ± 14.5ms     168ms …  205ms          0 ( 0%)        0%
  peak_rss           7.31MB ± 58.5KB    7.21MB … 7.34MB          0 ( 0%)        0%
  cpu_cycles          688M  ± 4.20M      684M  …  706M           1 ( 4%)        0%
  instructions       1.19G  ± 29.4      1.19G  … 1.19G           0 ( 0%)        0%
  cache_references    412K  ±  763K      239K  … 4.21M           2 ( 7%)        0%
  cache_misses       10.0K  ± 7.40K     7.90K  … 46.8K           2 ( 7%)        0%
  branch_misses       814K  ± 1.37K      813K  …  821K           1 ( 4%)        0%
Benchmark 2 (37 runs): zig-out/bin/token_reader Gtk-4.0.gir
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           136ms ± 13.8ms     115ms …  147ms          0 ( 0%)        ⚡- 27.7% ±  3.8%
  peak_rss           7.31MB ± 54.7KB    7.21MB … 7.34MB          8 (22%)          +  0.1% ±  0.4%
  cpu_cycles          462M  ± 1.87M      459M  …  466M           0 ( 0%)        ⚡- 32.8% ±  0.2%
  instructions       1.14G  ± 26.6      1.14G  … 1.14G           0 ( 0%)        ⚡-  4.1% ±  0.0%
  cache_references    236K  ± 4.86K      227K  …  244K           0 ( 0%)          - 42.7% ± 60.7%
  cache_misses       9.40K  ± 1.25K     7.88K  … 11.5K           0 ( 0%)          -  6.5% ± 24.6%
  branch_misses       815K  ± 1.01K      813K  …  817K           0 ( 0%)          +  0.1% ±  0.1%
```

```
Benchmark 1 (23 runs): zig-out/bin-old/reader Gtk-4.0.gir
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           225ms ± 14.2ms     199ms …  249ms          0 ( 0%)        0%
  peak_rss           7.25MB ±  100KB    7.08MB … 7.34MB          0 ( 0%)        0%
  cpu_cycles          823M  ± 12.2M      813M  …  847M           0 ( 0%)        0%
  instructions       1.43G  ± 23.0      1.43G  … 1.43G           0 ( 0%)        0%
  cache_references    757K  ±  129K      635K  … 1.07M           1 ( 4%)        0%
  cache_misses       13.7K  ± 1.18K     12.5K  … 17.2K           2 ( 9%)        0%
  branch_misses      1.43M  ± 3.35K     1.42M  … 1.43M           0 ( 0%)        0%
Benchmark 2 (31 runs): zig-out/bin/reader Gtk-4.0.gir
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           166ms ± 13.9ms     144ms …  175ms          0 ( 0%)        ⚡- 26.5% ±  3.4%
  peak_rss           7.27MB ± 81.8KB    7.08MB … 7.34MB          0 ( 0%)          +  0.3% ±  0.7%
  cpu_cycles          581M  ± 1.54M      579M  …  584M           0 ( 0%)        ⚡- 29.4% ±  0.5%
  instructions       1.38G  ± 16.0      1.38G  … 1.38G           9 (29%)        ⚡-  3.8% ±  0.0%
  cache_references    715K  ±  219K      563K  … 1.71M           3 (10%)          -  5.5% ± 13.6%
  cache_misses       13.5K  ± 1.31K     11.4K  … 16.5K           2 ( 6%)          -  1.2% ±  5.1%
  branch_misses      1.07M  ± 20.3K     1.05M  … 1.11M           5 (16%)        ⚡- 25.3% ±  0.6%
```