### PR TITLE
feat: move decoder type to options struct

### DIFF
--- a/bench/src/reader.zig
+++ b/bench/src/reader.zig
@@ -5,7 +5,9 @@ pub const main = @import("common.zig").main;
 
 pub fn runBench(data: []const u8) !void {
     var data_stream = std.io.fixedBufferStream(data);
-    var reader = xml.reader(std.heap.c_allocator, data_stream.reader(), xml.encoding.Utf8Decoder{}, .{});
+    var reader = xml.reader(std.heap.c_allocator, data_stream.reader(), .{
+        .DecoderType = xml.encoding.Utf8Decoder,
+    });
     defer reader.deinit();
     while (try reader.next()) |_| {}
 }

--- a/bench/src/token_reader.zig
+++ b/bench/src/token_reader.zig
@@ -5,6 +5,8 @@ pub const main = @import("common.zig").main;
 
 pub fn runBench(data: []const u8) !void {
     var data_stream = std.io.fixedBufferStream(data);
-    var token_reader = xml.tokenReader(data_stream.reader(), xml.encoding.Utf8Decoder{}, .{});
+    var token_reader = xml.tokenReader(data_stream.reader(), .{
+        .DecoderType = xml.encoding.Utf8Decoder,
+    });
     while (try token_reader.next()) |_| {}
 }

--- a/examples/read.zig
+++ b/examples/read.zig
@@ -20,7 +20,7 @@ pub fn main() !void {
     const input_file = try std.fs.cwd().openFile(input_path, .{});
     defer input_file.close();
     var input_buffered_reader = std.io.bufferedReader(input_file.reader());
-    var reader = xml.reader(allocator, input_buffered_reader.reader(), xml.encoding.DefaultDecoder{}, .{});
+    var reader = xml.reader(allocator, input_buffered_reader.reader(), .{});
     defer reader.deinit();
 
     while (try reader.next()) |event| {


### PR DESCRIPTION
Closes #20

This makes the API simpler to use. No flexibility is sacrificed, because users who want to pass in a non-default-initialized decoder object can just use the `TokenReader` and `Reader` `init` functions directly.