### PR TITLE
perf: apply memory optimizations to `TokenReader`

### DIFF
--- a/bench/src/token_reader.zig
+++ b/bench/src/token_reader.zig
@@ -8,5 +8,8 @@ pub fn runBench(data: []const u8) !void {
     var token_reader = xml.tokenReader(data_stream.reader(), .{
         .DecoderType = xml.encoding.Utf8Decoder,
     });
-    while (try token_reader.next()) |_| {}
+    while (true) {
+        const token = try token_reader.next();
+        if (token == .eof) break;
+    }
 }

--- a/src/Scanner.zig
+++ b/src/Scanner.zig
@@ -41,7 +41,7 @@
 //! - Not extensively tested/fuzzed.
 
 /// The data for the most recently returned token.
-token_data: Token.Data = .{ .ok = {} },
+token_data: Token.Data = undefined,
 /// The current state of the scanner.
 state: State = .start,
 /// Data associated with the current state of the scanner.
@@ -97,7 +97,7 @@ pub const Range = struct {
 ///   content or there are other necessary intervening factors, such as CDATA
 ///   in the middle of normal (non-CDATA) element content.
 ///
-/// For efficiency (avoiding copying when passing around tokens), `Token` is
+/// For efficiency (avoiding copying when passing around tokens), this is
 /// merely an enum specifying the token type. The actual token data is available
 /// in `Token.Data`, in the scanner's `token_data` field. The `fullToken`
 /// function can be used to get a `Token.Full`, which is a tagged union type and


### PR DESCRIPTION
These optimizations are analogous to those made in #26 for `Scanner`. The performance improvement for `Reader` is less significant, but still noticeable:

```
Benchmark 1 (48 runs): zig-out/bin-old/reader Gtk-4.0.gir
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           106ms ± 1.72ms     104ms …  110ms          0 ( 0%)        0%
  peak_rss           7.28MB ± 80.9KB    7.08MB … 7.34MB          0 ( 0%)        0%
  cpu_cycles          420M  ± 6.94M      413M  …  438M           0 ( 0%)        0%
  instructions       1.13G  ± 19.3      1.13G  … 1.13G           0 ( 0%)        0%
  cache_references    561K  ± 72.6K      477K  …  878K           2 ( 4%)        0%
  cache_misses       12.7K  ± 1.31K     11.3K  … 18.3K           3 ( 6%)        0%
  branch_misses      1.07M  ± 5.21K     1.07M  … 1.09M           0 ( 0%)        0%
Benchmark 2 (50 runs): zig-out/bin/reader Gtk-4.0.gir
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           101ms ± 1.08ms    98.9ms …  103ms          1 ( 2%)        ⚡-  4.9% ±  0.5%
  peak_rss           7.29MB ± 63.6KB    7.21MB … 7.34MB          0 ( 0%)          +  0.2% ±  0.4%
  cpu_cycles          398M  ± 4.24M      393M  …  410M           1 ( 2%)        ⚡-  5.2% ±  0.5%
  instructions       1.11G  ± 20.8      1.11G  … 1.11G           0 ( 0%)        ⚡-  1.5% ±  0.0%
  cache_references    404K  ±  244K      314K  … 1.82M           4 ( 8%)        ⚡- 28.0% ± 13.0%
  cache_misses       12.0K  ± 1.11K     10.1K  … 15.3K           0 ( 0%)        ⚡-  5.6% ±  3.8%
  branch_misses      1.10M  ± 2.89K     1.10M  … 1.12M           4 ( 8%)        💩+  2.8% ±  0.2%
```