### PR TITLE
feat: reader memory reuse improvements

### DIFF
--- a/bench/src/token_reader.zig
+++ b/bench/src/token_reader.zig
@@ -5,9 +5,10 @@ pub const main = @import("common.zig").main;
 
 pub fn runBench(data: []const u8) !void {
     var data_stream = std.io.fixedBufferStream(data);
-    var token_reader = xml.tokenReader(data_stream.reader(), .{
+    var token_reader = xml.tokenReader(std.heap.c_allocator, data_stream.reader(), .{
         .DecoderType = xml.encoding.Utf8Decoder,
     });
+    defer token_reader.deinit();
     while (true) {
         const token = try token_reader.next();
         if (token == .eof) break;


### PR DESCRIPTION
The intention is for this PR to address both #30 and #31 so some real benefits can be realized. Just implementing #30 by itself without any meaningful change to `Reader` to take advantage of the increased flexibility provides no benefit.