### PR TITLE
Add Writer.embed function to allow writing pre-formed XML without escaping anything

### DIFF
--- a/src/Writer.zig
+++ b/src/Writer.zig
@@ -183,6 +183,17 @@ pub fn text(writer: *Writer, s: []const u8) anyerror!void {
     writer.state = .text;
 }
 
+// insert some existing XML document without escaping anything
+pub fn embed(writer: *Writer, s: []const u8) anyerror!void {
+    switch (writer.state) {
+        .after_structure_end, .text => {},
+        .element_start => try writer.raw(">"),
+        .start, .after_bom, .after_xml_declaration, .end => unreachable,
+    }
+    try writer.raw(s);
+    writer.state = .after_structure_end;
+}
+
 fn newLineAndIndent(writer: *Writer) anyerror!void {
     if (writer.options.indent.len == 0) return;
 

--- a/src/Writer.zig
+++ b/src/Writer.zig
@@ -186,12 +186,15 @@ pub fn text(writer: *Writer, s: []const u8) anyerror!void {
 // insert some existing XML document without escaping anything
 pub fn embed(writer: *Writer, s: []const u8) anyerror!void {
     switch (writer.state) {
-        .after_structure_end, .text => {},
+        .start, .after_bom, .after_xml_declaration, .after_structure_end, .text, .end => {},
         .element_start => try writer.raw(">"),
-        .start, .after_bom, .after_xml_declaration, .end => unreachable,
     }
     try writer.raw(s);
-    writer.state = .after_structure_end;
+    writer.state = switch (writer.state) {
+        .start, .after_bom, .after_xml_declaration => .after_xml_declaration,
+        .element_start, .after_structure_end, .text => .text,
+        .end => .end,
+    };
 }
 
 fn newLineAndIndent(writer: *Writer) anyerror!void {

--- a/src/xml.zig
+++ b/src/xml.zig
@@ -467,6 +467,10 @@ pub fn GenericWriter(comptime SinkError: type) type {
         pub inline fn text(writer: *@This(), s: []const u8) WriteError!void {
             return @errorCast(writer.writer.text(s));
         }
+
+        pub inline fn embed(writer: *@This(), s: []const u8) WriteError!void {
+            return @errorCast(writer.writer.embed(s));
+        }
     };
 }
 


### PR DESCRIPTION
Useful for embedding one XML fragment into another