### PR TITLE
Feat/default namespaces

### DIFF
--- a/src/Writer.zig
+++ b/src/Writer.zig
@@ -839,12 +839,8 @@ test embed {
 /// declared immediately. Otherwise, it will be declared on the next element
 /// started. If/when `prefix` is null the namespace will be declared as a
 /// default namespace (no prefix) for the element.
-pub fn bindNs(writer: *Writer, prefix: ?[]const u8, ns: []const u8) anyerror!void {
-    if (prefix != null) {
-        try writer.bindNsInternal(try writer.addString(prefix.?), ns);
-    } else {
-        try writer.bindNsInternal(@enumFromInt(writer.strings.items.len), ns);
-    }
+pub fn bindNs(writer: *Writer, prefix: []const u8, ns: []const u8) anyerror!void {
+    try writer.bindNsInternal(try writer.addString(prefix), ns);
 }
 
 test bindNs {
@@ -867,7 +863,7 @@ test bindNs {
     try writer.bindNs("ex3", "http://example.com/ns3");
     try writer.elementEndEmpty();
     try writer.elementStart("ex4");
-    try writer.bindNs(null, "http://example.com/ex4");
+    try writer.bindNs("", "http://example.com/ex4");
     try writer.elementEndEmpty();
     try writer.elementEnd();
     try writer.eof();

--- a/src/Writer.zig
+++ b/src/Writer.zig
@@ -543,7 +543,9 @@ fn attributeInternal(writer: *Writer, prefix: []const u8, name: []const u8, valu
     try writer.write(" ");
     if (prefix.len > 0) {
         try writer.write(prefix);
-        try writer.write(":");
+        if(name.len > 0) {
+            try writer.write(":");
+        }
     }
     try writer.write(name);
     try writer.write("=\"");
@@ -836,8 +838,12 @@ test embed {
 /// If the writer is currently inside an element start, the namespace is
 /// declared immediately. Otherwise, it will be declared on the next element
 /// started.
-pub fn bindNs(writer: *Writer, prefix: []const u8, ns: []const u8) anyerror!void {
-    try writer.bindNsInternal(try writer.addString(prefix), ns);
+pub fn bindNs(writer: *Writer, prefix: ?[]const u8, ns: []const u8) anyerror!void {
+    if (prefix != null) {
+        try writer.bindNsInternal(try writer.addString(prefix.?), ns);
+    } else {
+        try writer.bindNsInternal(@enumFromInt(writer.strings.items.len), ns);
+    }
 }
 
 test bindNs {

--- a/src/Writer.zig
+++ b/src/Writer.zig
@@ -837,7 +837,8 @@ test embed {
 ///
 /// If the writer is currently inside an element start, the namespace is
 /// declared immediately. Otherwise, it will be declared on the next element
-/// started.
+/// started. If/when `prefix` is null the namespace will be declared as a
+/// default namespace (no prefix) for the element.
 pub fn bindNs(writer: *Writer, prefix: ?[]const u8, ns: []const u8) anyerror!void {
     if (prefix != null) {
         try writer.bindNsInternal(try writer.addString(prefix.?), ns);

--- a/src/Writer.zig
+++ b/src/Writer.zig
@@ -865,12 +865,16 @@ test bindNs {
     // declared regardless.
     try writer.bindNs("ex3", "http://example.com/ns3");
     try writer.elementEndEmpty();
+    try writer.elementStart("ex4");
+    try writer.bindNs(null, "http://example.com/ex4");
+    try writer.elementEndEmpty();
     try writer.elementEnd();
     try writer.eof();
 
     try expectEqualStrings(
         \\<ex:root xmlns:ex="http://example.com" ex:a="value">
         \\  <ex:element xmlns:ex2="http://example.com/ns2" ex2:a="value" xmlns:ex3="http://example.com/ns3"/>
+        \\  <ex4 xmlns="http://example.com/ex4"/>
         \\</ex:root>
         \\
     , raw.items);

--- a/src/xml.zig
+++ b/src/xml.zig
@@ -529,7 +529,7 @@ pub fn GenericWriter(comptime SinkError: type) type {
         }
 
         /// See `Writer.bindNs`.
-        pub inline fn bindNs(writer: *@This(), prefix: []const u8, ns: []const u8) WriteError!void {
+        pub inline fn bindNs(writer: *@This(), prefix: ?[]const u8, ns: []const u8) WriteError!void {
             return @errorCast(writer.writer.bindNs(prefix, ns));
         }
 

--- a/src/xml.zig
+++ b/src/xml.zig
@@ -529,7 +529,7 @@ pub fn GenericWriter(comptime SinkError: type) type {
         }
 
         /// See `Writer.bindNs`.
-        pub inline fn bindNs(writer: *@This(), prefix: ?[]const u8, ns: []const u8) WriteError!void {
+        pub inline fn bindNs(writer: *@This(), prefix: []const u8, ns: []const u8) WriteError!void {
             return @errorCast(writer.writer.bindNs(prefix, ns));
         }
 


### PR DESCRIPTION
👋 hey there, thanks for creating this project! 

ive been slowly working on building a netconf client in zig and am using zig-xml to parse responses from servers as well as craft messages to send to them. unless ive missed something (highly possible!) it seems that currently there is no way to set a non-prefixed namespace (or to set a default namespace basically) on an element. 

im sure some netconf servers behave better than others but at the very least the ones ive been testing with seem to be quite upset at me when prefixing the base netconf namespace. for example, sending the output from something like this:

```zig
    try writer.xmlDeclaration("UTF-8", null);
    try writer.elementStart("rpc");
    try writer.bindNs("nc", "urn:ietf:params:xml:ns:netconf:base:1.0");
    try writer.attribute("message-id", "101");
    try writer.elementStart("get-config");
    try writer.elementStart("source");
    try writer.elementStart("running");
    try writer.elementEnd();
    try writer.elementEnd();
    try writer.elementEnd();
    try writer.elementEnd();
    try writer.eof();
```

this server seems quite upset! with the changes here I can do all the same as above put set the prefix to `null` like:

```zig
    try writer.bindNs(null, "urn:ietf:params:xml:ns:netconf:base:1.0");
```

and my server happily returns its config. 

im not super savvy on what is or is not in the xml standards or if this is something you'd be willing to include, but was messing around to see if I could get it to work so figured id just chuck a pr your way to see if you were interested!

ive updated the `bindNs` test w/ an element setup like this, and the conformance tests still seem to pass (`zig build test` in the xmlconf directory seems happy still).

feel free to close or holler if you'd like to see any changes. thanks again!

carl