### PR TITLE
fix: temp fix to get things running on 0.14.0-dev.3287+65e7ede49

### DIFF
--- a/src/Reader.zig
+++ b/src/Reader.zig
@@ -2196,10 +2196,10 @@ fn shift(reader: *Reader) !void {
     if (reader.node == .element_end) {
         if (reader.options.namespace_aware) {
             var prefix_bindings = reader.ns_prefixes.pop();
-            prefix_bindings.deinit(reader.gpa);
+            prefix_bindings.?.deinit(reader.gpa);
         }
         const element_name_start = reader.element_names.pop();
-        reader.strings.shrinkRetainingCapacity(@intFromEnum(element_name_start));
+        reader.strings.shrinkRetainingCapacity(@intFromEnum(element_name_start.?));
     }
 }
 

--- a/src/Writer.zig
+++ b/src/Writer.zig
@@ -362,13 +362,13 @@ pub fn elementEnd(writer: *Writer) anyerror!void {
         .start, .after_bom, .after_xml_declaration, .end, .eof => unreachable,
     }
     try writer.write("</");
-    try writer.write(writer.string(name));
+    try writer.write(writer.string(name.?));
     try writer.write(">");
     writer.state = if (writer.element_names.items.len > 0) .after_structure_end else .end;
-    writer.strings.shrinkRetainingCapacity(@intFromEnum(name));
+    writer.strings.shrinkRetainingCapacity(@intFromEnum(name.?));
     if (writer.options.namespace_aware) {
         var ns_prefixes = writer.ns_prefixes.pop();
-        ns_prefixes.deinit(writer.gpa);
+        ns_prefixes.?.deinit(writer.gpa);
         writer.pending_ns.clearRetainingCapacity();
     }
 }


### PR DESCRIPTION
👋 hey again!

ive just been messing about getting some stuff working on current zig master (or close enough, whatever zvm latest got me :)) and saw that you've clearly already got some stuff in place for the pending 0.14.0 release! 

I noticed that using tip and `zig-0.14.0` branch/pr that things didn't compile due to the changes upstream to `popOrNull`/`pop`. this patch is just a down and dirty patch to get things compiling again.

I assume you'd want to check if the returned values from `pop` are null or not, and handle that nicely, but wasn't sure if there was already a convention/error to return in this case, so figured id just throw this out there and obviously am happy to tweak to however you'd like to see it if you'd like to include this. 

carl