### PR TITLE
chore: support updated build.zig.zon (zig 0.14.0 prep)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,7 @@
 .{
-    .name = "xml",
+    .name = .xml,
     .version = "0.1.0",
+    .fingerprint = 0x31f4d863dfcf3665, // Changing this has security and trust implications.
     .paths = .{
         "src",
         "LICENSE",

--- a/xmlconf/build.zig.zon
+++ b/xmlconf/build.zig.zon
@@ -1,6 +1,7 @@
 .{
-    .name = "xmlconf",
+    .name = .xmlconf,
     .version = "0.0.0",
+    .fingerprint = 0x9ff4914e2b429b9b, // Changing this has security and trust implications.
     .paths = .{
         "build.zig",
         "build.zig.zon",


### PR DESCRIPTION
👋 hey again!

I updated zig again to latest main and found [this](https://github.com/ziglang/zig/commit/d6a88ed74db270c14c669ab334f3ab715cfd2b76#diff-7e9bb30ed31335940f19e196f799a8966cbbbc5a1bf2804de4d90fc7035b847c) and the [tracking ussue](https://github.com/ziglang/zig/commit/d6a88ed74db270c14c669ab334f3ab715cfd2b76#diff-7e9bb30ed31335940f19e196f799a8966cbbbc5a1bf2804de4d90fc7035b847c) created some new stuff for us to have in build.zig.zon file.

tl;dr `zig init` now adds the fingerprint which should be generated and not change ever afaik. it also adds minimum zig version but I removed that here (though can ofc add it in if you're so inclined). lastly, the package name is now a enum literal instead. and the newer version of zig was quite upset when these were not present 😁 

obviously feel free to disregard, just figured since I had to figure out what was what for my project, figured id share the love and open this! 

edit: I re-ran tests and stuff and seems like no other fun breaking stuff shaking out, so hopefully this is good!

~~edit-edit: I *think* we're supposed to also add the .id field as well but im not sure yet if thats just something random we generate or if there is some significance to it/should be generated by zig tooling or not. so... will update if I figure something out!~~ j/k looks like it was id then changed to fingerprint. gotta love living on the bleeding edge haha