### PR TITLE
chore: Zig master compatibility for main library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        zig-version: [0.15.1, master]
+        zig-version: [0.15.2, master]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -25,6 +25,7 @@ jobs:
       - name: Test
         run: zig build test
       - name: Build examples
+        if: ${{ matrix.zig-version == '0.15.2' }}
         run: zig build install-examples
 
   build-docs:

--- a/src/Reader.zig
+++ b/src/Reader.zig
@@ -295,7 +295,7 @@ pub const Streaming = struct {
     };
 
     /// Asserts that `in` has a buffer of at least 2 bytes.
-    pub fn init(gpa: Allocator, in: *std.io.Reader, options: Options) @This() {
+    pub fn init(gpa: Allocator, in: *std.Io.Reader, options: Options) @This() {
         assert(in.buffer.len >= 2);
         return .{
             .in = in,
@@ -452,7 +452,7 @@ pub const Streaming = struct {
 };
 
 test Streaming {
-    var bytes: std.io.Reader = .fixed(
+    var bytes: std.Io.Reader = .fixed(
         \\<?xml version="1.0"?>
         \\<root>Hello, 世界 👋!</root>
         \\
@@ -485,7 +485,7 @@ test "streaming with UTF-16LE" {
 }
 
 fn testStreamingUtf16(comptime endian: std.builtin.Endian) !void {
-    var bytes: std.io.Reader = .fixed(utf16BytesLiteral(endian, "\u{FEFF}" ++
+    var bytes: std.Io.Reader = .fixed(utf16BytesLiteral(endian, "\u{FEFF}" ++
         \\<?xml version="1.0"?>
         \\<root>Hello, 世界 👋!</root>
         \\


### PR DESCRIPTION
The examples are still stuck on 0.15 for now, since they use IO which has major breaking changes on master.