### PR TITLE
fix: use .empty for Unmanaged type initialization (Zig 0.14+ compat)

### DIFF
--- a/src/Reader.zig
+++ b/src/Reader.zig
@@ -541,12 +541,12 @@ pub fn init(gpa: Allocator, options: Options, vtable: *const VTable) Reader {
         .options = options,
 
         .state = .start,
-        .spans = .{},
-        .attributes = .{},
-        .q_attributes = .{},
-        .strings = .{},
-        .element_names = .{},
-        .ns_prefixes = .{},
+        .spans = .empty,
+        .attributes = .empty,
+        .q_attributes = .empty,
+        .strings = .empty,
+        .element_names = .empty,
+        .ns_prefixes = .empty,
         .character = undefined,
 
         .vtable = vtable,

--- a/src/Writer.zig
+++ b/src/Writer.zig
@@ -101,10 +101,10 @@ pub fn init(gpa: Allocator, writer: *std.Io.Writer, options: Options) Writer {
         .options = options,
 
         .state = .start,
-        .strings = .{},
-        .element_names = .{},
-        .ns_prefixes = .{},
-        .pending_ns = .{},
+        .strings = .empty,
+        .element_names = .empty,
+        .ns_prefixes = .empty,
+        .pending_ns = .empty,
         .gen_ns_prefix_counter = 0,
 
         .out = writer,
@@ -330,7 +330,7 @@ fn elementStartInternal(writer: *Writer, prefix: []const u8, local: []const u8) 
     writer.state = .element_start;
 
     if (writer.options.namespace_aware) {
-        var ns_prefixes: std.AutoArrayHashMapUnmanaged(StringIndex, StringIndex) = .{};
+        var ns_prefixes: std.AutoArrayHashMapUnmanaged(StringIndex, StringIndex) = .empty;
         try ns_prefixes.ensureUnusedCapacity(writer.gpa, writer.pending_ns.count());
         var pending_ns_iter = writer.pending_ns.iterator();
         while (pending_ns_iter.next()) |pending_ns| {


### PR DESCRIPTION
Updates ArrayListUnmanaged and AutoArrayHashMapUnmanaged empty initialization from .{} to .empty.

In Zig 0.16-dev, .{} no longer works for these types — the compiler requires .empty instead. The .empty syntax has been available since Zig 0.14, so this change is backwards compatible.

**Files changed:**
- src/Reader.zig: 6 initializations updated
- src/Writer.zig: 5 initializations updated

All 68 tests pass on Zig 0.16.0-dev.2962.