### PR TITLE
zig 0.17.0 updates

### DIFF
--- a/src/Reader.zig
+++ b/src/Reader.zig
@@ -521,17 +521,17 @@ inline fn utf16BytesLiteral(comptime endian: std.builtin.Endian, comptime utf8: 
 }
 
 test "streaming with extremely long element name" {
-    const name = "a" ** 65536;
+    const name: [65536]u8 = @splat('a');
     var bytes: std.Io.Reader = .fixed("<" ++ name ++ "/>");
     var streaming_reader: xml.Reader.Streaming = .init(std.testing.allocator, &bytes, .{});
     defer streaming_reader.deinit();
     const reader = &streaming_reader.interface;
 
     try expectEqual(.element_start, try reader.read());
-    try expectEqualStrings(name, reader.elementName());
+    try expectEqualStrings(&name, reader.elementName());
 
     try expectEqual(.element_end, try reader.read());
-    try expectEqualStrings(name, reader.elementName());
+    try expectEqualStrings(&name, reader.elementName());
 
     try expectEqual(.eof, try reader.read());
 }
@@ -2148,7 +2148,12 @@ fn addAttributeValueString(reader: *Reader, raw_value: []const u8) !StringIndex 
 }
 
 fn checkElementEnd(reader: *Reader) !void {
-    const element_name = reader.string(reader.element_names.getLast());
+    const element_name = if (@hasDecl(@TypeOf(reader.element_names), "last")) // zig 0.17
+        reader.string((reader.element_names.last() orelse {
+            return reader.fatal(.element_end_mismatched, reader.elementNamePos());
+        }).*)
+    else
+        reader.string(reader.element_names.getLast());
     if (!std.mem.eql(u8, reader.elementNameUnchecked(), element_name)) {
         return reader.fatal(.element_end_mismatched, reader.elementNamePos());
     }


### PR DESCRIPTION
Hello,

I'm opening this because zig-xml is somewhere down [DVUI](https://github.com/david-vanderson/dvui) dependency list and I'm busy wanting to have incremental compilation work for the project ;-)

The diff is surprisingly small. So much so than I could even maintain backwards compatibility. 
I didn't look much into the library itself, just enough to get DVUI compile.

Feel free to merge if it makes sense to you. 

Cheers.

PS : 
of course 0.17 is not out yet, and you might want to wait that, or take another course of action, no pressure whatsoever, it was more to share that anything else.
