### PR TITLE
fix: deref of StringIndex - cropped up in zig 0.17.0-dev.1640+2597da025

### DIFF
--- a/src/Reader.zig
+++ b/src/Reader.zig
@@ -2518,7 +2518,7 @@ fn checkElementEnd(reader: *Reader) !void {
     const element_name = if (@hasDecl(@TypeOf(reader.element_names), "last")) // zig 0.17
         reader.string((reader.element_names.last() orelse {
             return reader.fatal(.element_end_mismatched, reader.elementNamePos());
-        }).*)
+        }))
     else
         reader.string(reader.element_names.getLast());
     if (!std.mem.eql(u8, reader.elementNameUnchecked(), element_name)) {


### PR DESCRIPTION
tiny fix I saw this morning when bumping to latest zig. tests passed and didnt seem like this was an issue anywhere else. figured id throw it out there. not sure if the other 0.16.x dev branch is where it should go but that appears further behind anyway (missing the splat changes and such). 